### PR TITLE
:sparkles: feat: adicionar listagem completa de clientes com informações relacionadas

### DIFF
--- a/SIGO-BackEnd/SIGO/Controllers/ClienteController.cs
+++ b/SIGO-BackEnd/SIGO/Controllers/ClienteController.cs
@@ -21,5 +21,16 @@ namespace SIGO.Controllers
             _response = new Response();
         }
 
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var clienteDTO = await _clienteService.GetAll();
+
+            _response.Code = ResponseEnum.SUCCESS;
+            _response.Data = clienteDTO;
+            _response.Message = "Clientes listados com sucesso";
+
+            return Ok(_response);
+        }
     }
 }

--- a/SIGO-BackEnd/SIGO/Data/Repositories/ClienteRepository.cs
+++ b/SIGO-BackEnd/SIGO/Data/Repositories/ClienteRepository.cs
@@ -1,4 +1,5 @@
-﻿using SIGO.Data.Interfaces;
+﻿using Microsoft.EntityFrameworkCore;
+using SIGO.Data.Interfaces;
 using SIGO.Objects.Models;
 
 namespace SIGO.Data.Repositories
@@ -11,5 +12,15 @@ namespace SIGO.Data.Repositories
         {
             _context = context;
         }
+        public override async Task<IEnumerable<Cliente>> Get()
+        {
+            return await _context.Clientes
+                .Include(c => c.EnderecoClientes)
+                    .ThenInclude(ec => ec.Endereco)
+                .Include(c => c.Telefones)
+                .ToListAsync();
+        }
+
+
     }
 }

--- a/SIGO-BackEnd/SIGO/Data/Repositories/GenericRepository.cs
+++ b/SIGO-BackEnd/SIGO/Data/Repositories/GenericRepository.cs
@@ -19,6 +19,7 @@ namespace SIGO.Data.Repositories
             return await _dbSet.ToListAsync();
         }
 
+
         public async Task<T> GetById(int id)
         {
             return await _dbSet.FindAsync(id);

--- a/SIGO-BackEnd/SIGO/Objects/Dtos/Entities/ClienteDTO.cs
+++ b/SIGO-BackEnd/SIGO/Objects/Dtos/Entities/ClienteDTO.cs
@@ -22,6 +22,8 @@
         public int Situacao { get; set; }
 
         public List<TelefoneDTO> Telefones { get; set; } = new();
-        public List<EnderecoDTO> Enderecos { get; set; } = new();
+        public List<EnderecoClienteDTO> Enderecos { get; set; } = new();
+
+
     }
 }

--- a/SIGO-BackEnd/SIGO/Objects/Dtos/Entities/EnderecoClienteDTO.cs
+++ b/SIGO-BackEnd/SIGO/Objects/Dtos/Entities/EnderecoClienteDTO.cs
@@ -7,8 +7,9 @@ namespace SIGO.Objects.Dtos.Entities
     {
         public string Complemento { get; set; }
         public int ClienteId { get; set; }
-        public Cliente Cliente { get; set; }
+        public ClienteDTO Cliente { get; set; } // <- usar DTO, pq tava dando erro pois não tava enviando de la
         public int EnderecoId { get; set; }
-        public Endereco Endereco { get; set; }
+        public EnderecoDTO Endereco { get; set; } // <- usar DTO
     }
+
 }

--- a/SIGO-BackEnd/SIGO/Objects/Dtos/Mappings/MappingsProfile.cs
+++ b/SIGO-BackEnd/SIGO/Objects/Dtos/Mappings/MappingsProfile.cs
@@ -1,0 +1,24 @@
+﻿using AutoMapper;
+using SIGO.Objects.Dtos.Entities;
+using SIGO.Objects.Models;
+
+namespace SIGO.Objects.Dtos.Mappings
+{
+    public class MappingProfile : Profile
+    {
+        public MappingProfile()
+        {
+            CreateMap<Cliente, ClienteDTO>()
+                .ForMember(dest => dest.Enderecos,
+                    opt => opt.MapFrom(src => src.EnderecoClientes.Select(ec => ec.Endereco)))
+            .ReverseMap();
+
+            CreateMap<Endereco, EnderecoClienteDTO>().ReverseMap();
+            CreateMap<Endereco, EnderecoDTO>().ReverseMap();
+            CreateMap<Telefone, TelefoneDTO>().ReverseMap();
+            CreateMap<EnderecoCliente, EnderecoClienteDTO>().ReverseMap();
+
+
+        }
+    }
+}

--- a/SIGO-BackEnd/SIGO/SIGO.csproj
+++ b/SIGO-BackEnd/SIGO/SIGO.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -19,10 +19,6 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Objects\Dtos\Mappings\" />
   </ItemGroup>
 
 </Project>

--- a/SIGO-BackEnd/SIGO/Services/Entities/ClienteService.cs
+++ b/SIGO-BackEnd/SIGO/Services/Entities/ClienteService.cs
@@ -17,6 +17,10 @@ namespace SIGO.Services.Entities
             _clienteRepository = clienteRepository;
             _mapper = mapper;
         }
-        
+        public override async Task<IEnumerable<ClienteDTO>> GetAll()
+        {
+            var entities = await _clienteRepository.Get();
+            return _mapper.Map<IEnumerable<ClienteDTO>>(entities);
+        }
     }
 }


### PR DESCRIPTION

Adiciona funcionalidade para listar todos os clientes incluindo seus endereços e telefones relacionados através de mapeamento automático com AutoMapper.

- Implementa mapeamento de Endereco para EnderecoDTO
- Configura relacionamentos N para N no MappingProfile
- Ajusta DTOs para suportar as relações entre entidades
- Garante que getAll retorne dados completos do cliente

Quebra: altera estrutura de mapeamento existente para suportar relações